### PR TITLE
Make migration only use provided QueryRunner

### DIFF
--- a/src/migration/1549202832774-CreateAdminUser.ts
+++ b/src/migration/1549202832774-CreateAdminUser.ts
@@ -8,7 +8,7 @@ export class CreateAdminUser1547919837483 implements MigrationInterface {
     user.password = "admin";
     user.hashPassword();
     user.role = "ADMIN";
-    const userRepository = getRepository(User);
+    const userRepository = queryRunner.manager.getRepository(User);
     await userRepository.save(user);
   }
 


### PR DESCRIPTION
Make sure all actions in the migration is part of the transaction.