### PR TITLE
Allow node to run build

### DIFF
--- a/ormconfig.json
+++ b/ormconfig.json
@@ -4,13 +4,13 @@
    "synchronize": true,
    "logging": false,
    "entities": [
-      "src/entity/**/*.ts"
+      "build/entity/**/*.js"
    ],
    "migrations": [
-      "src/migration/**/*.ts"
+      "build/migration/**/*.js"
    ],
    "subscribers": [
-      "src/subscriber/**/*.ts"
+      "build/subscriber/**/*.js"
    ],
    "cli": {
       "entitiesDir": "src/entity",


### PR DESCRIPTION
I believe this is a proper fix to
`import { Entity, PrimaryGeneratedColumn,
            ^
SyntaxError: Unexpected token {`

Error.